### PR TITLE
Use the main task as an idle task; Create a job  (task) that spawns the 3 sub tasks and waits for them to finish; other cleanup

### DIFF
--- a/Code/Kernel/Includes/scheduler.h
+++ b/Code/Kernel/Includes/scheduler.h
@@ -7,8 +7,11 @@
 struct task;
 typedef struct task task;
 
-void schedule();
-void init_scheduler();
-void yield();
+void schedule(void);
+void init_scheduler(void);
+void yield(void);
 
+void lock_scheduler(void);
+// Call unlock_scheduler at the very start of every task!
+void unlock_scheduler(void);
 #endif

--- a/Code/Kernel/Sources/PCB.c
+++ b/Code/Kernel/Sources/PCB.c
@@ -11,7 +11,7 @@ task* create_task(uintptr_t task_entry_function) {
         new_task->state = READY;
         new_task->pc = task_entry_function;
         new_task->base_sp = (uintptr_t *)malloc(STACK_SIZE);
-        new_task->sp = new_task->sp + STACK_SIZE; // Set SP to top of stack
+        new_task->sp = new_task->base_sp + STACK_SIZE; // Set SP to top of stack
 
 //      This would apply to a user task
 //      new_task->esp0 = (uintptr_t)malloc(STACK_SIZE) + STACK_SIZE;

--- a/Code/Kernel/Sources/PIT.c
+++ b/Code/Kernel/Sources/PIT.c
@@ -18,7 +18,9 @@ void pit_handler(void) { // each 10ms will be interrupt.
     setCursorPosition(24, 0);
     printf("Bitmap state: Pages ( %d / %d ) (TASKS: %d) - PIT Ticks - %d \n", COLOR_BLACK_ON_WHITE, pagesAllocated, NUM_PAGES, nowTasks, tick_count);
     pic_send_eoi(0);
-    schedule(); // Will enable interrupts
+    lock_scheduler();
+    schedule();
+    unlock_scheduler();
 }
 
 uint32_t get_tick_count(void) {

--- a/Code/Kernel/Sources/PIT.c
+++ b/Code/Kernel/Sources/PIT.c
@@ -18,9 +18,7 @@ void pit_handler(void) { // each 10ms will be interrupt.
     setCursorPosition(24, 0);
     printf("Bitmap state: Pages ( %d / %d ) (TASKS: %d) - PIT Ticks - %d \n", COLOR_BLACK_ON_WHITE, pagesAllocated, NUM_PAGES, nowTasks, tick_count);
     pic_send_eoi(0);
-    lock_scheduler();
     schedule();
-    unlock_scheduler();
 }
 
 uint32_t get_tick_count(void) {

--- a/Code/Kernel/Sources/PIT.c
+++ b/Code/Kernel/Sources/PIT.c
@@ -10,15 +10,15 @@ void pit_init(uint32_t frequency) {
     outPort(PIT_CHANNEL0, (uint8_t)((divisor >> 8) & 0xFF));
 }
 
-void pit_handler(void) { // each 10ms will be interrupt. 
-    __asm__("cli"); // CLI to avoid recursive.    
+void pit_handler(void) { // each 10ms will be interrupt.
+    // IRQ handlers ar set as interrupt gates in the IDT so interrupts
+    // will always be off a this point as a result. No CLI necessary.
     tick_count++;
 
     setCursorPosition(24, 0);
     printf("Bitmap state: Pages ( %d / %d ) (TASKS: %d) - PIT Ticks - %d \n", COLOR_BLACK_ON_WHITE, pagesAllocated, NUM_PAGES, nowTasks, tick_count);
-    
     pic_send_eoi(0);
-    schedule(); // Enable Interrupt happening in switch_to_task();
+    schedule(); // Will enable interrupts
 }
 
 uint32_t get_tick_count(void) {

--- a/Code/Kernel/Sources/PIT.c
+++ b/Code/Kernel/Sources/PIT.c
@@ -18,9 +18,8 @@ void pit_handler(void) { // each 10ms will be interrupt.
     setCursorPosition(24, 0);
     printf("Bitmap state: Pages ( %d / %d ) (TASKS: %d) - PIT Ticks - %d \n", COLOR_BLACK_ON_WHITE, pagesAllocated, NUM_PAGES, nowTasks, tick_count);
     pic_send_eoi(0);
-    lock_scheduler();
+    // Don't need to lock the scheduler from within the interrupt handler
     schedule();
-    unlock_scheduler();
 }
 
 uint32_t get_tick_count(void) {

--- a/Code/Kernel/Sources/PIT.c
+++ b/Code/Kernel/Sources/PIT.c
@@ -18,7 +18,9 @@ void pit_handler(void) { // each 10ms will be interrupt.
     setCursorPosition(24, 0);
     printf("Bitmap state: Pages ( %d / %d ) (TASKS: %d) - PIT Ticks - %d \n", COLOR_BLACK_ON_WHITE, pagesAllocated, NUM_PAGES, nowTasks, tick_count);
     pic_send_eoi(0);
+    lock_scheduler();
     schedule();
+    unlock_scheduler();
 }
 
 uint32_t get_tick_count(void) {

--- a/Code/Kernel/Sources/kernel.c
+++ b/Code/Kernel/Sources/kernel.c
@@ -3,8 +3,11 @@
 
 //volatile uint32_t count = 0;
 
+volatile uint32_t tasks_finished = 0;
+
 void task1_entry() {
     uint32_t count1 = 0;
+    unlock_scheduler();
     setCursorPosition(15, 0);
     printf("Test1 Start - %d\n", GREEN_ON_BLACK_SUCCESS, count1);
 
@@ -19,11 +22,13 @@ void task1_entry() {
     setCursorPosition(15, 30);
     printf("Test1 Finished - %d\n", GREEN_ON_BLACK_SUCCESS, count1);
     set_task_state(current, TERMINATED);
+    tasks_finished++;
     yield();
 }
 
 void task2_entry() {
     uint32_t count2 = 0;
+    unlock_scheduler();
     setCursorPosition(16, 0);
     printf("Test2 Start - %d\n", GREEN_ON_BLACK_SUCCESS, count2);
 //    for (int i = 1; i <= 10000000; i++) {
@@ -38,11 +43,13 @@ void task2_entry() {
     setCursorPosition(16, 30);
     printf("Test2 Finished - %d\n", GREEN_ON_BLACK_SUCCESS, count2);
     set_task_state(current, TERMINATED);
+    tasks_finished++;
     yield();
 }
 
 void task3_entry() {
     uint32_t count3 = 0;
+    unlock_scheduler();
     setCursorPosition(17, 0);
     printf("Test3 Start - %d\n", GREEN_ON_BLACK_SUCCESS, count3);
 
@@ -55,21 +62,37 @@ void task3_entry() {
         __asm__("sti");
     }
     setCursorPosition(17, 30);
-    printf("Test1 Finished - %d\n", GREEN_ON_BLACK_SUCCESS, count3);
+    printf("Test3 Finished - %d\n", GREEN_ON_BLACK_SUCCESS, count3);
+    set_task_state(current, TERMINATED);
+    tasks_finished++;
+    yield();
+}
+
+void job1_entry() {
+    // Create sample work tasks
+    unlock_scheduler();
+    setCursorPosition(19,0);
+    create_task((uintptr_t)task1_entry);
+    create_task((uintptr_t)task2_entry);
+    create_task((uintptr_t)task3_entry);
+
+    // This job isn't done until the 3 tasks are finished
+    while (tasks_finished < 3)
+        // Once we perform a check immediately yield to the next task
+        yield();
+
+    setCursorPosition(18, 0);
+    printf("DONE\n", GREEN_ON_BLACK_SUCCESS);
     set_task_state(current, TERMINATED);
     yield();
 }
 
-void task_main() {
-    while (nowTasks > 2) {
-        yield();  // Allow other tasks to run
-    }
-
-    setCursorPosition(18, 0);
-    printf("DONE\n", GREEN_ON_BLACK_SUCCESS);
-
-    while (1) {
-        __asm__("hlt");  // Halt indefinitely
+// Mark the task_main as not returning
+__attribute__((noreturn)) void task_main() {
+    while (true) {
+        // Wait until next interrupt
+        // This effectively becomes an idle task
+        __asm__("hlt");
     }
 }
 
@@ -84,18 +107,18 @@ void _start(void) {
     init_bitmap();
     pic_init();
     init_free_list();
-    init_scheduler();
 
-    // Create sample work tasks
-    setCursorPosition(19,0);
-    create_task((uintptr_t)task1_entry);
-    create_task((uintptr_t)task2_entry);
-    create_task((uintptr_t)task3_entry);
-    create_task((uintptr_t)task_main);
+    // Creates a PCB for the main task (this code) using current stack
+    // and initializes the task list
+    init_scheduler();
+    __asm__("sti");
 
     setCursorPosition(0,24);
     print_task_and_count();
-    __asm__("sti");
 
-    while (1) __asm__ ("hlt");  // Loop indefinitely
+    // Create an initial counting job to perform.
+    // This job will creates 3 subtasks when it starts
+    create_task((uintptr_t)job1_entry);
+
+    task_main(); // Do main task. task_main will not return
 }

--- a/Code/Kernel/Sources/kernel.c
+++ b/Code/Kernel/Sources/kernel.c
@@ -90,9 +90,13 @@ void job1_entry() {
 // Mark the task_main as not returning
 __attribute__((noreturn)) void task_main() {
     while (true) {
-        // Wait until next interrupt
-        // This effectively becomes an idle task
-        __asm__("hlt");
+        // If there are no other tasks besides main running then
+        // hlt until next interrupt
+        if (nowTasks == 1)
+            __asm__("hlt");
+        // Otherwise immediately yield to next task
+        else
+            yield();
     }
 }
 

--- a/Code/Kernel/Sources/scheduler.c
+++ b/Code/Kernel/Sources/scheduler.c
@@ -40,9 +40,7 @@ void schedule(void) {
         next_task = next_task->next;
     }
 
-    lock_scheduler();
     switch_to_task(next_task);
-    unlock_scheduler();
 
     // CLI/STI critical section probably unneeded if you modify your interrupt
     // handler to save the CursorPosition at the start and restore it before returning
@@ -74,5 +72,7 @@ void init_scheduler(void) {
 }
 
 void yield(void) {
+    lock_scheduler();
     schedule();
+    unlock_scheduler();
 }


### PR DESCRIPTION
Changes in this pull:
- Fix bug I introduced with PCB stack creation. A typo would have caused some kind of exception to occur failing almost immediately. Sorry about that.
- Use the main task as an idle task. The main task never exits.
- Make the main task PID=0
- Create a job (task) that spawns the 3 sub tasks and waits for them to finish.
- Create `lock_scheduler` and `unlock_scheduler` similar to Brendan's multitasking tutorial. This version doesn't support multiple CPUs.
- `unlock_scheduler` must be called at the beginning of every task that is created. There is a better way of doing this but I will commit the more straightforward solution.
- Other multitasking cleanup.

Current deficiencies: 
- ISR interrupt handling doesn't save everything (including the segment registers). 
- Doesn't fully support user mode (ring>0) tasks/processes.
- May be other minor bugs I haven't noticed yet.
